### PR TITLE
Pass input instead of *builder

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -26,7 +26,7 @@ func newBuilder[T any](t promptType, input string) (*builder[T], error) {
 	var pb promptBuilder
 	switch t {
 	case promptUserRequest:
-		pb = newUserRequest[T](b)
+		pb = newUserRequest[T](b.input)
 	case promptProgram:
 		pb = newProgram[T](b)
 	default:

--- a/builder.go
+++ b/builder.go
@@ -26,9 +26,9 @@ func newBuilder[T any](t promptType, input string) (*builder[T], error) {
 	var pb promptBuilder
 	switch t {
 	case promptUserRequest:
-		pb = newUserRequest[T](b.input)
+		pb = newUserRequest[T](input)
 	case promptProgram:
-		pb = newProgram[T](b)
+		pb = newProgram[T](input)
 	default:
 		return nil, fmt.Errorf("unknown prompt type %s", t)
 	}

--- a/program.go
+++ b/program.go
@@ -24,7 +24,7 @@ indentation and no properties with the value undefined:`
 )
 
 type program[T any] struct {
-  input string
+	input string
 	built   string
 }
 

--- a/program.go
+++ b/program.go
@@ -24,12 +24,12 @@ indentation and no properties with the value undefined:`
 )
 
 type program[T any] struct {
-	builder *builder[T]
+  input string
 	built   string
 }
 
-func newProgram[T any](b *builder[T]) *program[T] {
-	return &program[T]{builder: b}
+func newProgram[T any](i string) *program[T] {
+  return &program[T]{input: i}
 }
 
 func (b *program[T]) string() (string, error) {
@@ -61,7 +61,7 @@ func (b *program[T]) string() (string, error) {
 func (b *program[T]) prompt() string {
 	var sb strings.Builder
 	sb.WriteString(newline("The following is a user request:"))
-	sb.WriteString(newline(b.builder.input))
+	sb.WriteString(newline(b.input))
 	sb.WriteString(newline(programPromptInstructions))
 
 	return sb.String()

--- a/typechat_test.go
+++ b/typechat_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type mockModelClient struct {
-	response []byte
+	response string
 	err      error
 }
 
-func (m mockModelClient) Do(ctx context.Context, prompt string) ([]byte, error) {
+func (m mockModelClient) Do(ctx context.Context, prompt string) (response string, err error) {
 	return m.response, m.err
 }
 
@@ -23,7 +23,7 @@ func TestTypeChat(t *testing.T) {
 	t.Run("it should generate the prompt and return the result", func(t *testing.T) {
 		ctx := context.Background()
 		m := mockModelClient{
-			response: []byte(`{"sentiment": "positive"}`),
+			response: `{"sentiment": "positive"}`,
 		}
 		p := NewPrompt[Result](m, "That game was awesome!")
 		result, err := p.Execute(ctx)
@@ -72,10 +72,10 @@ func TestTypeChat(t *testing.T) {
 			t.Errorf("Expected no error, got %v", err)
 		}
 		m := mockModelClient{
-			response: b,
+			response: string(b),
 		}
 		p := NewPrompt[API](m, "")
-		result, err := p.ExecuteProgram(ctx)
+		result, err := p.CreateProgram(ctx)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}

--- a/user_request.go
+++ b/user_request.go
@@ -15,12 +15,12 @@ indentation and no properties with the value undefined:`
 )
 
 type userRequest[T any] struct {
-	builder *builder[T]
+	input string
 	built   string
 }
 
-func newUserRequest[T any](b *builder[T]) *userRequest[T] {
-	return &userRequest[T]{builder: b}
+func newUserRequest[T any](i string) *userRequest[T] {
+  return &userRequest[T]{input: i}
 }
 
 func (b *userRequest[T]) string() (string, error) {
@@ -45,7 +45,7 @@ func (b *userRequest[T]) string() (string, error) {
 func (b *userRequest[T]) prompt() string {
 	var sb strings.Builder
 	sb.WriteString(newline("The following is a user request:"))
-	sb.WriteString(newline(b.builder.input))
+	sb.WriteString(newline(b.input))
 	sb.WriteString(newline(userRequestPromptInstructions))
 
 	return sb.String()


### PR DESCRIPTION
The bidirectional reference between `userRequest` and `builder` is a little smelly. Since `userRequest` only uses builder to reference `builder.input` I figure it makes sense to pass the input directly.

Also some tests were failing so those are fixed.