### PR TITLE
Supports chat role messages

### DIFF
--- a/typechat_test.go
+++ b/typechat_test.go
@@ -11,7 +11,7 @@ type mockModelClient struct {
 	err      error
 }
 
-func (m mockModelClient) Do(ctx context.Context, prompt string) (response string, err error) {
+func (m mockModelClient) Do(ctx context.Context, prompt []Message) (response string, err error) {
 	return m.response, m.err
 }
 


### PR DESCRIPTION
Instead of sending the prompt as one user message
we now split the instructions and user prompt into the appropiate role. Repair messages also now
include the history + assistant response + new system message to repair the item