### PR TITLE
Add credits section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,11 @@ This library is under development and still requires more work to solidify the p
 - Setup CI
 
 Get involved! Lots todo!
+
+## Credits
+
+Special thanks to:
+- Mike Kavouras (@mikekavouras)
+- Jason Etcovitch (@jasonetco)
+
+for their contributions and inspiration in the development of this project.


### PR DESCRIPTION
Related to #4

Adds a "Credits" section to the README.md file to acknowledge contributions and inspiration from Mike Kavouras and Jason Etcovitch.

- Introduces a new "Credits" section at the end of the README.md document.
- Acknowledges Mike Kavouras (@mikekavouras) and Jason Etcovitch (@jasonetco) for their contributions and inspiration in the development of the project, with each name appearing on a separate line.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josebalius/typechat-go/issues/4?shareId=0b98b5af-e1ad-4457-be61-76d0618a15d3).