### PR TITLE
Add credits section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,8 @@ This library is under development and still requires more work to solidify the p
 - Setup CI
 
 Get involved! Lots todo!
+
+## Credits
+
+- Mike Kavouras (@mikekavouras)
+- Jason Etcovitch (@jasonetco)


### PR DESCRIPTION
Related to #4

Adds a Credits section to the README.md to acknowledge Mike Kavouras and Jason Etcovitch for their contributions.

- Introduces a new "Credits" section at the bottom of the README.md file.
- Acknowledges Mike Kavouras and Jason Etcovitch by listing their names and GitHub handles.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josebalius/typechat-go/issues/4?shareId=d3dc7d4a-8d0e-48e3-904c-0fcef0ca989b).