### PR TITLE
Add credits section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,8 @@ This library is under development and still requires more work to solidify the p
 - Setup CI
 
 Get involved! Lots todo!
+
+## Credits
+
+- Thanks to Mike Kavouras (@mikekavouras) for his contributions.
+- Thanks to Jason Etcovitch (@jasonetco) for his inspiration.


### PR DESCRIPTION
Related to #4

Adds a "Credits" section to the README.md file to acknowledge Mike Kavouras and Jason Etcovitch for their contributions and inspiration.

- Introduces a new section titled "Credits" at the bottom of the README.md, following the "Contributing" section.
- Acknowledges Mike Kavouras for his contributions and Jason Etcovitch for his inspiration, with separate lines dedicated to each.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josebalius/typechat-go/issues/4?shareId=1577fc23-3552-438e-9b18-2c28d22998c2).