### PR TITLE
Add credits section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,8 @@ This library is under development and still requires more work to solidify the p
 - Setup CI
 
 Get involved! Lots todo!
+
+## Credits
+
+- Mike Kavouras (@mikekavouras)
+- Jason Etcovitch (@jasonetco)


### PR DESCRIPTION
Related to #4

Adds a "Credits" section to the README.md to acknowledge Mike Kavouras and Jason Etcovitch for their contributions.

- Introduces a new section titled "Credits" at the end of the README.md file.
- Acknowledges Mike Kavouras and Jason Etcovitch by mentioning their contributions and including their GitHub usernames (@mikekavouras and @jasonetco).


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josebalius/typechat-go/issues/4?shareId=7673981b-6f27-43d6-b796-50adc1f2d60e).