### PR TITLE
Add credits section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,8 @@ This library is under development and still requires more work to solidify the p
 - Setup CI
 
 Get involved! Lots todo!
+
+## Credits
+
+- Mike Kavouras (@mikekavouras)
+- Jason Etcovitch (@jasonetco)


### PR DESCRIPTION
Related to #4

Adds a "Credits" section to the README.md file to acknowledge the contributions of Mike Kavouras and Jason Etcovitch.

- Introduces a new "Credits" section towards the end of the README.md file, just before any license information.
- Acknowledges Mike Kavouras and Jason Etcovitch for their contributions, including their GitHub usernames (@mikekavouras and @jasonetco) as per the issue request.
- Ensures each acknowledgment is on a separate line, maintaining clarity and readability.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josebalius/typechat-go/issues/4?shareId=63b53e85-c60f-4fbc-8294-b6b52ff2ee6a).