### PR TITLE
Add credits section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ This library is under development and still requires more work to solidify the p
 - Setup CI
 
 Get involved! Lots todo!
+
+## Credits
+
+We would like to extend our heartfelt thanks to Mike Kavouras (@mikekavouras) and Jason Etcovitch (@jasonetco) for their inspiration and contributions to this project. Their expertise and support have been invaluable in the development of typechat-go.


### PR DESCRIPTION
Related to #4

Adds a Credits section to the README.md file to acknowledge Mike Kavouras and Jason Etcovitch for their contributions and inspiration towards the typechat-go project.

- Introduces a new "Credits" section at the end of the README.md document.
- Acknowledges Mike Kavouras (@mikekavouras) and Jason Etcovitch (@jasonetco) for their inspiration and contributions to the project, expressing heartfelt thanks.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josebalius/typechat-go/issues/4?shareId=e92bfc29-0e9a-4233-87f0-4f2da2100198).